### PR TITLE
Use `VTS_` prefix for environment variable names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "vtubestudio-cli"
-version = "0.2.1-alpha.0"
+version = "0.3.0-alpha.0"
 dependencies = [
  "anyhow",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vtubestudio-cli"
-version = "0.2.1-alpha.0"
+version = "0.3.0-alpha.0"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ For more complex tasks, you might want to look at client libraries like
 [VTube Studio API]: https://github.com/DenchiSoft/VTubeStudio
 [`vtubestudio-rs`]: https://github.com/walfie/vtubestudio-rs
 
+## Download
+
+Check the [releases page](https://github.com/walfie/vtubestudio-cli/releases)
+to download prebuilt binaries for your platform.
+
 ## Initialization
 
 `vts` reads auth token info from a JSON config file whose default location depends on platform.
@@ -29,7 +34,7 @@ pop-up in the app asking for confirmation) and save the token for use in future
 calls. The plugin name and developer name can be customized with
 `--plugin-name` and `--developer-name`, respectively.
 
-## Config location
+### Config file location
 
 By default, the config file can be found at:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ The primary use case is to do infrequent actions such as triggering hotkeys or
 registering custom parameters, without needing to establish a long-running
 websocket connection.
 
+For more complex tasks, you might want to look at client libraries like
+[`vtubestudio-rs`] (the Rust library that this program uses under the hood).
+
 [VTube Studio API]: https://github.com/DenchiSoft/VTubeStudio
+[`vtubestudio-rs`]: https://github.com/walfie/vtubestudio-rs
 
 ## Initialization
 
@@ -33,8 +37,8 @@ By default, the config file can be found at:
 * macOS: `$HOME/Library/Application Support/com.github.walfie.vtubestudio-cli/config.json`
 * Linux: `$XDG_CONFIG_DIR/vtubestudio-cli/config.json` or `$HOME/.config/vtubestudio-cli/config.json`
 
-This path can be overridden by setting the `CONFIG_FILE` environment variable
-or passing the `--config-file` flag.
+This path can be overridden by setting the `VTS_CONFIG` environment variable or
+passing the `--config-file` flag.
 
 You can also run `vts config path` to show the path to the config, or `vts
 config show` to show the contents of the config file.

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,7 +8,7 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug, Clone)]
 pub struct Args {
     /// Overwrite path to config file.
-    #[structopt(env, long)]
+    #[structopt(env = "VTS_CONFIG", long)]
     pub config_file: Option<PathBuf>,
     /// Avoid pretty-printing JSON.
     #[structopt(long)]
@@ -23,7 +23,7 @@ pub struct Config {
     pub host: String,
     #[structopt(short, long, default_value = "8001")]
     pub port: u16,
-    #[structopt(long, env, hide_env_values = true)]
+    #[structopt(long, env = "VTS_TOKEN", hide_env_values = true)]
     pub token: Option<String>,
     #[structopt(long, default_value = "VTube Studio CLI")]
     pub plugin_name: String,


### PR DESCRIPTION
Names like `CONFIG_FILE` and `TOKEN` are too generic.