### PR TITLE
Allow negative numbers as arguments

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug, Clone)]
+#[structopt(global_setting = structopt::clap::AppSettings::AllowNegativeNumbers)]
 pub struct Args {
     /// Overwrite path to config file.
     #[structopt(env = "VTS_CONFIG", long)]


### PR DESCRIPTION
Previously a negative number would be interpreted as a flag.

https://github.com/TeXitoi/structopt/issues/129