### PR TITLE
Add item commands and add new flags to existing ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,7 +1148,9 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vtubestudio"
-version = "0.7.0-alpha.0"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b08dc8de9b2615b5e344be56c3b7d4b1c1b98f8c946b1f856ce3aa82f2a21f"
 dependencies = [
  "displaydoc",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,9 +1148,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vtubestudio"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e95c7709f3e11cba2bfdf4c7260bc0d81811f9085b49f2c0ca5f929646980bc"
+version = "0.7.0-alpha.0"
 dependencies = [
  "displaydoc",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ structopt = "0.3.25"
 tokio = { version = "1.14.0", features = ["macros", "time"] }
 tracing = "0.1.29"
 tracing-subscriber = "0.3.1"
-vtubestudio = "0.6.0"
+vtubestudio = { path = "../vtubestudio-rs" } # TODO

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ structopt = "0.3.25"
 tokio = { version = "1.14.0", features = ["macros", "time"] }
 tracing = "0.1.29"
 tracing-subscriber = "0.3.1"
-vtubestudio = { path = "../vtubestudio-rs" } # TODO
+vtubestudio = "0.7.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -123,15 +123,21 @@ pub struct InjectParam {
     pub weight: Option<f64>,
     #[structopt(long)]
     pub face_found: bool,
+    /// Whether to use `add` mode instead of `set` mode.
+    #[structopt(long)]
+    pub add: bool,
 }
 
 #[derive(StructOpt, Debug, Clone)]
 pub enum HotkeysCommand {
-    /// List the available hotkeys for a model.
+    /// List the available hotkeys for a model or Live2D item.
     List {
         /// Model ID.
         #[structopt(long)]
         model_id: Option<String>,
+        /// Live2D item file name.
+        #[structopt(long)]
+        live2d_file: Option<String>,
     },
     /// Trigger hotkey by ID or name.
     Trigger(TriggerHotkey),
@@ -145,6 +151,9 @@ pub struct TriggerHotkey {
     /// Find and trigger the first hotkey with this name, if it exists.
     #[structopt(long, conflicts_with = "id")]
     pub name: Option<String>,
+    /// Trigger hotkey for this item instance ID.
+    #[structopt(long)]
+    pub item: Option<String>,
 }
 
 #[derive(StructOpt, Debug, Clone)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -65,6 +65,9 @@ pub enum Command {
     Ndi(NdiCommand),
     /// Actions related to physics.
     Physics(PhysicsCommand),
+    /// Actions related to items.
+    #[structopt(alias = "item")]
+    Items(ItemsCommand),
 }
 
 #[derive(StructOpt, Debug, Clone)]
@@ -336,6 +339,92 @@ impl SetPhysicsCommand {
             Self::Multiplier(conf) => &conf.kind,
         }
     }
+}
+
+#[derive(StructOpt, Debug, Clone)]
+pub enum ItemsCommand {
+    /// List items.
+    List {
+        /// Include available spots.
+        #[structopt(long)]
+        spots: bool,
+        /// Include available instances.
+        #[structopt(long)]
+        instances: bool,
+        /// Include available file names.
+        #[structopt(long)]
+        files: bool,
+        /// Only include specific file name.
+        #[structopt(long)]
+        with_file_name: Option<String>,
+        /// Only include specific instance ID.
+        #[structopt(long)]
+        with_instance_id: Option<String>,
+    },
+    /// Load item into scene.
+    Load(ItemLoadCommand),
+    /// Unload item from scene.
+    Unload(ItemUnloadCommand),
+}
+
+#[derive(StructOpt, Debug, Clone)]
+pub struct ItemLoadCommand {
+    /// File name. E.g., `some_item_name.jpg`.
+    pub file_name: String,
+    /// X position.
+    #[structopt(short, default_value = "0")]
+    pub x: f64,
+    /// Y position.
+    #[structopt(short, default_value = "0")]
+    pub y: f64,
+    #[structopt(long, default_value = "0.32")]
+    pub size: f64,
+    /// Rotation, in degrees.
+    #[structopt(long, default_value = "0")]
+    pub rotation: i32,
+    /// Fade time, in seconds. Should be between `0` and `2`.
+    #[structopt(long, default_value = "0")]
+    pub fade_time: f64,
+    /// Item order. If the order is taken, VTube Studio will automatically try to find the
+    /// next available order, unless `fail_if_order_taken` is `true`.
+    #[structopt(long)]
+    pub order: Option<i32>,
+    /// Set to `true` to fail with an `ItemOrderAlreadyTaken` error if the desired `order`
+    /// is already taken.
+    #[structopt(long)]
+    pub fail_if_order_taken: bool,
+    /// Smoothing, between `0` and `1`.
+    #[structopt(long, default_value = "0")]
+    pub smoothing: f64,
+    /// Whether the item is censored.
+    #[structopt(long)]
+    pub censored: bool,
+    /// Whether the item is flipped.
+    #[structopt(long)]
+    pub flipped: bool,
+    /// Whether the item is locked.
+    #[structopt(long)]
+    pub locked: bool,
+}
+
+#[derive(StructOpt, Debug, Clone)]
+pub struct ItemUnloadCommand {
+    /// Unload all items in the scene.
+    #[structopt(long)]
+    pub all: bool,
+    /// Whether to unload all items loaded by this plugin.
+    #[structopt(long)]
+    pub from_this_plugin: bool,
+    /// Whether to allow unloading items that have been loaded by the user or other
+    /// plugins.
+    #[structopt(long)]
+    pub from_other_plugins: bool,
+    /// Request specific instance IDs to be unloaded.
+    #[structopt(long)]
+    pub id: Vec<String>,
+    /// Request specific file names to be unloaded.
+    #[structopt(long)]
+    pub file: Vec<String>,
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -368,6 +368,8 @@ pub enum ItemsCommand {
     Unload(ItemUnloadCommand),
     /// Move item.
     Move(ItemMoveCommand),
+    /// Set item animation properties.
+    Animation(ItemAnimationCommand),
 }
 
 #[derive(StructOpt, Debug, Clone)]
@@ -472,6 +474,39 @@ const FADE_MODES: &'static [&'static str] = &[
     "overshoot",
     "zip",
 ];
+
+#[derive(StructOpt, Debug, Clone)]
+pub struct ItemAnimationCommand {
+    /// Item instance ID.
+    pub item_instance_id: String,
+    #[structopt(long)]
+    /// Frame rate for animated items, clamped between `0.1` and `120`.
+    pub framerate: Option<f64>,
+    /// Jump to a specific frame, zero-indexed.
+    ///
+    /// May return an error if the frame index is invalid, or if the item type does not
+    /// support animation.
+    #[structopt(long)]
+    pub frame: Option<i32>,
+    /// Brightness.
+    #[structopt(long)]
+    pub brightness: Option<f64>,
+    /// Opacity.
+    #[structopt(long)]
+    pub opacity: Option<f64>,
+    /// List of frame indices that the animation will automatically stop playing on.
+    #[structopt(long, conflicts_with = "reset-stop-frames")]
+    pub stop_frame: Vec<i32>,
+    /// Unset auto-stop-frames.
+    #[structopt(long)]
+    pub reset_stop_frames: bool,
+    /// Play the animation.
+    #[structopt(long, conflicts_with = "stop")]
+    pub play: bool,
+    /// Stop the animation.
+    #[structopt(long, conflicts_with = "play")]
+    pub stop: bool,
+}
 
 #[derive(Debug, Copy, Clone)]
 pub enum StrengthOrWind {

--- a/src/args.rs
+++ b/src/args.rs
@@ -166,6 +166,20 @@ pub enum ArtmeshesCommand {
     List,
     /// Tint matching art meshes.
     Tint(Tint),
+    Select {
+        /// Text shown over the art mesh selection list.
+        #[structopt(long)]
+        set_text: Option<String>,
+        /// Text shown when the user presses the `?` button.
+        #[structopt(long)]
+        set_help: Option<String>,
+        /// Number of meshes that should be selected.
+        #[structopt(long)]
+        count: Option<i32>,
+        /// Preselect these meshes.
+        #[structopt(long)]
+        preselect: Vec<String>,
+    },
 }
 
 #[derive(StructOpt, Debug, Clone)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
 use structopt::StructOpt;
+use vtubestudio::data::{EnumString, FadeMode};
 
 #[derive(StructOpt, Debug, Clone)]
 #[structopt(global_setting = structopt::clap::AppSettings::AllowNegativeNumbers)]
@@ -365,6 +366,8 @@ pub enum ItemsCommand {
     Load(ItemLoadCommand),
     /// Unload item from scene.
     Unload(ItemUnloadCommand),
+    /// Move item.
+    Move(ItemMoveCommand),
 }
 
 #[derive(StructOpt, Debug, Clone)]
@@ -426,6 +429,49 @@ pub struct ItemUnloadCommand {
     #[structopt(long)]
     pub file: Vec<String>,
 }
+
+#[derive(StructOpt, Debug, Clone)]
+pub struct ItemMoveCommand {
+    pub id: String,
+    #[structopt(long, parse(try_from_str = parse_duration::parse))]
+    pub duration: Duration,
+    #[structopt(
+        long,
+        parse(from_str = parse_fade_mode),
+        default_value = "linear",
+        possible_values = FADE_MODES
+    )]
+    pub fade_mode: EnumString<FadeMode>,
+    #[structopt(short)]
+    pub x: Option<i32>,
+    #[structopt(short)]
+    pub y: Option<i32>,
+    #[structopt(long)]
+    pub size: Option<f64>,
+    #[structopt(long)]
+    pub rotation: Option<i32>,
+    #[structopt(long)]
+    pub order: Option<i32>,
+    #[structopt(long)]
+    pub set_flip: bool,
+    #[structopt(long)]
+    pub flip: bool,
+    #[structopt(long)]
+    pub user_can_stop: bool,
+}
+
+fn parse_fade_mode(value: &str) -> EnumString<FadeMode> {
+    EnumString::<FadeMode>::new_from_str(value.to_owned())
+}
+
+const FADE_MODES: &'static [&'static str] = &[
+    "linear",
+    "easeIn",
+    "easeOut",
+    "easeBoth",
+    "overshoot",
+    "zip",
+];
 
 #[derive(Debug, Copy, Clone)]
 pub enum StrengthOrWind {

--- a/src/main.rs
+++ b/src/main.rs
@@ -566,6 +566,29 @@ async fn handle_items_command(client: &mut Client, command: ItemsCommand) -> Res
             let resp = client.send(&req).await?;
             print(&resp)?;
         }
+        Animation(value) => {
+            let animation_play_state = value.play || !value.stop;
+            let set_auto_stop_frames = !value.stop_frame.is_empty() || value.reset_stop_frames;
+            let auto_stop_frames = if value.reset_stop_frames {
+                vec![]
+            } else {
+                value.stop_frame
+            };
+            let req = ItemAnimationControlRequest {
+                item_instance_id: value.item_instance_id,
+                framerate: value.framerate,
+                frame: value.frame,
+                brightness: value.brightness,
+                opacity: value.opacity,
+                set_auto_stop_frames,
+                auto_stop_frames,
+                set_animation_play_state: value.play || value.stop,
+                animation_play_state,
+            };
+
+            let resp = client.send(&req).await?;
+            print(&resp)?;
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,6 +320,24 @@ async fn handle_artmeshes_command(client: &mut Client, command: ArtmeshesCommand
                 tokio::time::sleep(req.duration).await;
             }
         }
+
+        Select {
+            set_text,
+            set_help,
+            count,
+            preselect,
+        } => {
+            let resp = client
+                .send(&ArtMeshSelectionRequest {
+                    text_override: set_text,
+                    help_override: set_help,
+                    requested_art_mesh_count: count.unwrap_or(0),
+                    active_art_meshes: preselect,
+                })
+                .await?;
+
+            print(&resp)?;
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,7 +213,7 @@ async fn handle_params_command(client: &mut Client, command: ParamsCommand) -> R
             let resp = client
                 .send(&InjectParameterDataRequest {
                     face_found: req.face_found,
-                    mode: mode.into(),
+                    mode: Some(mode.into()),
                     parameter_values: vec![ParameterValue {
                         id: req.id,
                         value: req.value,

--- a/src/main.rs
+++ b/src/main.rs
@@ -545,6 +545,27 @@ async fn handle_items_command(client: &mut Client, command: ItemsCommand) -> Res
             let resp = client.send(&req).await?;
             print(&resp)?;
         }
+        Move(value) => {
+            let item = ItemToMove {
+                item_instance_id: value.id,
+                time_in_seconds: value.duration.as_secs_f64(),
+                fade_mode: value.fade_mode,
+                position_x: value.x,
+                position_y: value.y,
+                size: value.size,
+                rotation: value.rotation,
+                order: value.order,
+                set_flip: value.set_flip,
+                flip: value.flip,
+                user_can_stop: value.user_can_stop,
+            };
+            let req = ItemMoveRequest {
+                items_to_move: vec![item],
+            };
+
+            let resp = client.send(&req).await?;
+            print(&resp)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
* Adds commands:
  * `vts items list`
  * `vts items load`
  * `vts items unload`
  * `vts items move`
  * `vts items animation`
  * `vts artmeshes select` (usable on VTS beta branch)

* `vts params inject` accepts an `--add` flag to use `add` mode instead of the default `set` mode.
* `vts hotkeys list` accepts a `--live2d-file` argument to get hotkeys for a Live2D item.
* `vts hotkeys trigger` accepts a `--item` argument to trigger a hotkey for a specific item instance.
